### PR TITLE
Updates version in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: base32
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Mikael Karlsson <i8myshoes@gmail.com>


### PR DESCRIPTION
You've tagged version 0.1.1, but shard.yml still says 0.1.0. This caused an error when trying to include the shard in another project.

This fixes the shard.yml, but you might want to repoint the tag at this commit where the versions match up.

---

Thanks for this shard by the way! I'm using it in my shard [CrOTP](https://github.com/philnash/crotp) for one time passwords and it totally saved me writing a base32 encoder myself.