### PR TITLE
NUL byte decoding is broken and may corrupt data.

### DIFF
--- a/spec/base32_spec.cr
+++ b/spec/base32_spec.cr
@@ -89,4 +89,10 @@ describe Base32 do
     Base32.hex_decode_string("CPNMUOJ1").should eq("fooba")
     Base32.hex_decode_string("CPNMUOJ1E8").should eq("foobar")
   end
+
+  it "encodes/decodes with NUL bytes" do
+    str = "\0foo\0bar\0"
+    str2 = Base32.decode_string(Base32.encode(str))
+    str2.should eq str
+  end
 end


### PR DESCRIPTION
Add spec for NUL bytes.

A fix is provided in PR #5.