### PR TITLE
Corrects integer division when creating IO::Memory.

### DIFF
--- a/src/base32.cr
+++ b/src/base32.cr
@@ -32,7 +32,7 @@ module Base32
 
   # :nodoc:
   private def to_base32(data, pad : Bool, chars : Array(Char)) : String
-    mio = IO::Memory.new((data.bytesize / 5) * 8)
+    mio = IO::Memory.new((data.bytesize // 5) * 8)
 
     data.to_slice.each_slice(5) do |slice|
       bits = 0_u64
@@ -69,7 +69,7 @@ module Base32
 
   # :nodoc:
   private def from_base32(data, map : Hash(Char, Int)) : Slice(UInt8)
-    mio = IO::Memory.new((data.bytesize / 8) * 5)
+    mio = IO::Memory.new((data.bytesize // 8) * 5)
 
     data.to_slice.select { |s| !['\n'.ord, '\r'.ord, '='.ord].includes?(s) }.each_slice(8) do |slice|
       bits = 0_u64


### PR DESCRIPTION
Crystal 0.30.0 deprecated using `/` as integer division in favour of `//`. This seems to have come into effect in 0.31.0.